### PR TITLE
Implement unplanning a course

### DIFF
--- a/app/assets/stylesheets/_courses.css.scss
+++ b/app/assets/stylesheets/_courses.css.scss
@@ -1,10 +1,8 @@
-.new-taken-course-button {
-  @extend .button-primary;
+.taken-course-button {
   float: left;
 }
 
-.new-planned-course-button {
-  @extend .new-taken-course-button;
+.planned-course-button {
   margin-left: percentage(5px/1000px);
 }
 

--- a/app/controllers/planned_courses_controller.rb
+++ b/app/controllers/planned_courses_controller.rb
@@ -1,7 +1,7 @@
 class PlannedCoursesController < ApplicationController
   before_filter :authenticate_user!
-  before_action :set_planned_course, only: [:show, :edit, :update, :destroy]
-  after_action  :verify_authorized
+  before_action :set_and_authorize_planned_course, only: [:show, :edit, :update, :destroy]
+  after_action :verify_authorized
 
   # GET /plans/:plan_id/planned_courses/new
   def new
@@ -26,12 +26,18 @@ class PlannedCoursesController < ApplicationController
   # TODO: implement patch/put action
 
   # DELETE /planned_courses/1
-  # TODO: implement delete action
+  def destroy
+    if @planned_course.delete
+      redirect_to :back
+    else
+      flash.now![:alert] = "Error deleting user."
+    end
+  end
 
   private
 
   # Use callbacks to share common setup or constraints between actions.
-  def set_planned_course
+  def set_and_authorize_planned_course
     @planned_course = PlannedCourse.find(params[:id])
     authorize @planned_course
   end

--- a/app/decorators/plan_decorator.rb
+++ b/app/decorators/plan_decorator.rb
@@ -14,6 +14,7 @@ class PlanDecorator
   end
 
   def taken_quarter_sections
+    return [] unless statistics.any_taken_courses?
     first = statistics.first_taken_quarter
     last = statistics.last_taken_quarter
     quarters = Quarter.from(first: first, last: last)
@@ -21,6 +22,7 @@ class PlanDecorator
   end
 
   def planned_quarter_sections
+    return [] unless statistics.any_planned_courses?
     last_taken_quarter = statistics.last_taken_quarter
     if last_taken_quarter.nil?
       first = statistics.first_planned_quarter

--- a/app/decorators/plan_decorator.rb
+++ b/app/decorators/plan_decorator.rb
@@ -14,15 +14,20 @@ class PlanDecorator
   end
 
   def taken_quarter_sections
-    first = Quarter.new(statistics.first_taken_quarter)
-    last = Quarter.new(statistics.last_taken_quarter)
+    first = statistics.first_taken_quarter
+    last = statistics.last_taken_quarter
     quarters = Quarter.from(first: first, last: last)
     generate_quarter_sections_for(quarters, taken_courses)
   end
 
   def planned_quarter_sections
-    first = Quarter.new(statistics.last_taken_quarter).next_quarter.code
-    last = Quarter.new(statistics.last_planned_quarter)
+    last_taken_quarter = statistics.last_taken_quarter
+    if last_taken_quarter.nil?
+      first = statistics.first_planned_quarter
+    else
+      first = last_taken_quarter.next_quarter
+    end
+    last = statistics.last_planned_quarter
     quarters = Quarter.from(first: first, last: last)
     generate_quarter_sections_for(quarters, planned_courses)
   end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -39,7 +39,7 @@ module CoursesHelper
   end
 
   def path_to_planned_course(plan, course)
-    match = plan.planned_courses.find do |planned_course|
+    match = plan.planned_courses.detect do |planned_course|
       planned_course.course_id = course.id
     end
     planned_course_path(match)

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -13,15 +13,20 @@ module CoursesHelper
     course.department + course.level
   end
 
-  def enable_taken_button?(user, active_plan, course)
-    !course_taken?(user, course) && (active_plan.nil? || !course_planned?(active_plan, course))
+  def show_enabled_taken_button?(user, plan, course)
+    !course_taken?(user, course) && (plan.nil? || !course_planned?(plan, course))
   end
 
-  def enable_add_to_plan_button?(active_plan, course)
+  def show_add_to_plan_button?(plan, course)
     user_signed_in? &&
-      !active_plan.nil? &&
-      !course_planned?(active_plan, course) &&
+      !plan.nil? &&
+      !course_planned?(plan, course) &&
       !course_taken?(current_user, course)
+  end
+
+  def show_unplan_button?(plan, course)
+    return false if plan.nil?
+    course_planned?(plan, course)
   end
 
   def show_new_course_button_if_admin
@@ -33,7 +38,12 @@ module CoursesHelper
     course.degree_requirement.humanize.downcase
   end
 
-  private
+  def path_to_planned_course(plan, course)
+    match = plan.planned_courses.find do |planned_course|
+      planned_course.course_id = course.id
+    end
+    planned_course_path(match)
+  end
 
   def course_planned?(plan, course)
     plan.planned_courses_course_ids.include?(course.id)

--- a/app/views/courses/_course.html.haml
+++ b/app/views/courses/_course.html.haml
@@ -16,23 +16,25 @@
         data: { confirm: "Are you sure you want to delete course: #{course.title}?" }
   %p.course_description= course.description
   - if user_signed_in?
-    - if enable_taken_button?(current_user, active_plan, course)
+    - if show_enabled_taken_button?(current_user, active_plan, course)
       = button_to "taken",
         new_user_taken_course_path(user_id: current_user.id, course_id: course.id),
         remote: true,
         method: :get,
-        class: "new-taken-course-button"
+        class: "btn btn-primary taken-course-button"
     - else
-      %button.new-taken-course-button{ disabled: true }
+      %button.btn.btn-default.taken-course-button{ disabled: true }
         taken
-    - if enable_add_to_plan_button?(active_plan, course)
+    - if show_add_to_plan_button?(active_plan, course)
       = button_to "add to plan",
         new_plan_planned_course_path(plan_id: active_plan.id, course_id: course.id),
         remote: true,
         method: :get,
-        class: "new-planned-course-button"
+        class: "btn btn-primary planned-course-button"
+    - elsif show_unplan_button?(active_plan, course)
+      = button_to "unplan", path_to_planned_course(active_plan, course), method: :delete, class: "btn btn-default"
     - else
-      %button.new-planned-course-button{ disabled: true }
+      %button.btn.btn-default.planned-course-button{ disabled: true }
         planned
 .clearfix
 

--- a/app/views/pages/_plan_courses.html.haml
+++ b/app/views/pages/_plan_courses.html.haml
@@ -22,13 +22,18 @@
       %h3.col-xs-12= planned_quarter_section[:title]
       - planned_quarter_section[:courses].each do |planned_course|
         .col-xs-12.col-md-4.plan-planned-course
-          %h4= planned_course.full_id
-          %h5= planned_course.title
-          %p.plan-course-description= planned_course.description
-          - problems = @plan.get_problems_for(planned_course)
-          - unless problems.size == 0
-            .problems-found
-              %span.glyphicon.glyphicon-warning-sign
-              %span.sr-only Warning!
-              - problems.each do |problem|
-                = content_tag(:p, problem)
+          .row
+            .col-xs-12.col-md-9
+              %h4= planned_course.full_id
+              %h5= planned_course.title
+            .col-xs-12.col-md-3
+              = button_to "unplan", planned_course_path(planned_course), method: :delete, class: "btn btn-default"
+            .col-xs-12
+              %p.plan-course-description= planned_course.description
+              - problems = @plan.get_problems_for(planned_course)
+              - unless problems.size == 0
+                .problems-found
+                  %span.glyphicon.glyphicon-warning-sign
+                  %span.sr-only Warning!
+                  - problems.each do |problem|
+                    = content_tag(:p, problem)

--- a/app/views/pages/_plan_courses.html.haml
+++ b/app/views/pages/_plan_courses.html.haml
@@ -23,10 +23,10 @@
       - planned_quarter_section[:courses].each do |planned_course|
         .col-xs-12.col-md-4.plan-planned-course
           .row
-            .col-xs-12.col-md-9
+            .col-xs-9
               %h4= planned_course.full_id
               %h5= planned_course.title
-            .col-xs-12.col-md-3
+            .col-xs-3
               = button_to "unplan", planned_course_path(planned_course), method: :delete, class: "btn btn-default"
             .col-xs-12
               %p.plan-course-description= planned_course.description

--- a/spec/features/pages/planner_spec.rb
+++ b/spec/features/pages/planner_spec.rb
@@ -92,4 +92,21 @@ feature "Visiting the planner page" do
     visit planner_path
     expect(page).to have_content("You need to sign in or sign up before continuing.")
   end
+  scenario "as a user with a planned course and no taken courses" do
+    planned_course = create :planned_course, plan: plan
+    signin_user user
+    visit planner_path
+    expect(page).to have_title(full_title(plan.name))
+    expect(page).to have_css("h1", "#{ plan.name }")
+    expect(page).to have_content(planned_course.full_id)
+  end
+  scenario "as a user with a taken course and no planned courses" do
+    taken_course = create :taken_course, user: user
+    plan.save
+    signin_user user
+    visit planner_path
+    expect(page).to have_title(full_title(plan.name))
+    expect(page).to have_css("h1", "#{ plan.name }")
+    expect(page).to have_content(taken_course.full_id)
+  end
 end

--- a/spec/features/planned_courses/planned_course_delete_spec.rb
+++ b/spec/features/planned_courses/planned_course_delete_spec.rb
@@ -1,11 +1,12 @@
-feature "Deleting a planned course", js: true, slow: true do
+feature "Deleting a planned course" do
   let!(:user) { create :user }
-  let!(:plan) { create :plan }
+  let!(:plan) { create :plan, user: user }
   let!(:planned_course) { create :planned_course, plan: plan }
-  before { js_signin_user user }
+  before { signin_user user }
 
   scenario "signed in user deletes planned course from planner page" do
-    visit root_path
+    visit planner_path
+    expect(page).to have_button("unplan")
     click_button "unplan"
     expect(page).not_to have_content(planned_course.full_id)
   end

--- a/spec/features/planned_courses/planned_course_delete_spec.rb
+++ b/spec/features/planned_courses/planned_course_delete_spec.rb
@@ -1,0 +1,19 @@
+feature "Deleting a planned course", js: true, slow: true do
+  let!(:user) { create :user }
+  let!(:plan) { create :plan }
+  let!(:planned_course) { create :planned_course, plan: plan }
+  before { js_signin_user user }
+
+  scenario "signed in user deletes planned course from planner page" do
+    visit root_path
+    click_button "unplan"
+    expect(page).not_to have_content(planned_course.full_id)
+    expect(page).to have_deletion_message
+  end
+
+  private
+
+  def have_deletion_message
+    have_content "#{course.full_id} removed from plan"
+  end
+end

--- a/spec/features/planned_courses/planned_course_delete_spec.rb
+++ b/spec/features/planned_courses/planned_course_delete_spec.rb
@@ -8,12 +8,5 @@ feature "Deleting a planned course", js: true, slow: true do
     visit root_path
     click_button "unplan"
     expect(page).not_to have_content(planned_course.full_id)
-    expect(page).to have_deletion_message
-  end
-
-  private
-
-  def have_deletion_message
-    have_content "#{course.full_id} removed from plan"
   end
 end

--- a/spec/features/planned_courses/planned_course_delete_spec.rb
+++ b/spec/features/planned_courses/planned_course_delete_spec.rb
@@ -7,7 +7,14 @@ feature "Deleting a planned course" do
   scenario "signed in user deletes planned course from planner page" do
     visit planner_path
     expect(page).to have_button("unplan")
-    click_button "unplan"
+    expect { click_button "unplan" }.to change(PlannedCourse, :count).by(-1)
     expect(page).not_to have_content(planned_course.full_id)
+  end
+
+  scenario "signed in user deletes planned course from courses page" do
+    visit courses_path
+    expect(page).to have_button("unplan")
+    expect { click_button "unplan" }.to change(PlannedCourse, :count).by(-1)
+    expect(page).not_to have_button("unplan")
   end
 end

--- a/spec/policies/planned_course_policy_spec.rb
+++ b/spec/policies/planned_course_policy_spec.rb
@@ -12,7 +12,7 @@ describe PlannedCoursePolicy do
   let(:other_users_planned_course)   { FactoryGirl.build :planned_course,
                                                    plan: other_users_plan }
 
-  shared_examples_for "all permission policies" do
+  shared_examples_for "a typical planned_course policy" do
     it "raises error if not signed in" do
       expect { described_class.new(visitor, PlannedCourse).create? }
         .to raise_error(Pundit::NotAuthorizedError)
@@ -26,18 +26,18 @@ describe PlannedCoursePolicy do
   end
 
   permissions :new? do
-    it_should_behave_like "all permission policies"
+    it_should_behave_like "a typical planned_course policy"
   end
 
   permissions :create? do
-    it_should_behave_like "all permission policies"
+    it_should_behave_like "a typical planned_course policy"
   end
 
   permissions :update? do
-    it_should_behave_like "all permission policies"
+    it_should_behave_like "a typical planned_course policy"
   end
 
   permissions :destroy? do
-    it_should_behave_like "all permission policies"
+    it_should_behave_like "a typical planned_course policy"
   end
 end


### PR DESCRIPTION
Basically a more user-friendly alias for deleting an instance of PlannedCourse for the given user. Allows unplanning a `PlannedCourse` from both the "Courses" page and the "Planner" page.